### PR TITLE
fix cpu rate multiplier

### DIFF
--- a/metrics/kubelet.go
+++ b/metrics/kubelet.go
@@ -818,18 +818,20 @@ func (kubelet *Kubelet) GetMetrics(
 
 				rateMetric := *metric
 				rateMetric.Name += "_rate"
+				var multiplier int64 = 1e9
 
 				// TODO: cleanup when values are sent as floats
 				// covert seconds to milliseconds
 				if strings.Contains(rateMetric.Name, "seconds") {
 					rateMetric.Value *= 1000
+					multiplier = 1e6
 				}
 
 				// Container metrics use controller name & kind as entity name & kind
 				addMetricRate(
 					rateMetric.ControllerKind,
 					rateMetric.ControllerName,
-					1e9,
+					multiplier,
 					&rateMetric,
 				)
 			}


### PR DESCRIPTION
we convert CPU throttle seconds to milliseconds then while calculating the CPU rate we multiply it by 1e9 which makes it less than Nanos `(1e9 * cpu_throttle_in_millies / (duration in Nanos)` which output wrong percentage because the units does not match each other

Signed-off-by: Khaled K. Badr <khaledkbadr@outlook.com>